### PR TITLE
solving reload issues in subscription details

### DIFF
--- a/client/src/+assets/account.tsx
+++ b/client/src/+assets/account.tsx
@@ -20,7 +20,7 @@ export const Account: NextPage = () => {
   const [purchaseDate, setPurchaseDate] = useState<Date>()
   const [published, setPublished] = useState<DDO[]>([])
   const [downloaded, setDownloaded] = useState<DDO[]>([])
-  const { bookmarks, setBookmarks, getCurrentUserSubscription } = useContext(User)
+  const { bookmarks, setBookmarks, getCurrentUserSubscription, userSubscriptions } = useContext(User)
   const { sdk } = Catalog.useNevermined()
   const { walletAddress, getProvider } = MetaMask.useWallet()
   const subscriptionErrorText = "You don't have any current subscription. Only users with a subscription are allowed to publish"
@@ -46,6 +46,13 @@ export const Account: NextPage = () => {
     const downloadedDDO = await Promise.all(
       downloaded.map(async (did: any) => await sdk.assets.resolve(did))
     )
+    
+    setBookmarks(bookmarksDDO)
+    setPublished(publishedDDO)
+    setDownloaded(downloadedDDO)
+  }
+
+  const loadSubscription = async () => {
 
     let subscriptionsEvents = await getUserSubscription(sdk, getProvider(), walletAddress, getCurrentUserSubscription()?.did)
     subscriptionsEvents = subscriptionsEvents.sort(
@@ -53,9 +60,6 @@ export const Account: NextPage = () => {
     )
     const lastSuscriptionPurchase: Date = subscriptionsEvents ? subscriptionsEvents[0]?.date : undefined
     setPurchaseDate(lastSuscriptionPurchase)
-    setBookmarks(bookmarksDDO)
-    setPublished(publishedDDO)
-    setDownloaded(downloadedDDO)
   }
 
   useEffect(() => {
@@ -64,6 +68,13 @@ export const Account: NextPage = () => {
     }
     loadUserInfo()
   }, [sdk, walletAddress])
+
+  useEffect(() => {
+    if (!sdk?.profiles) {
+      return
+    }
+    loadSubscription()
+  }, [userSubscriptions])
 
   const publishAsset = () => {
     if (!getCurrentUserSubscription()) {

--- a/client/src/components/+account/subscriptions.tsx
+++ b/client/src/components/+account/subscriptions.tsx
@@ -1,20 +1,29 @@
-import React from 'react'
 import { UiText, UiLayout } from '@nevermined-io/styles'
 import { UserSubscription } from '../../shared/constants'
 import {SUBSCRIPTION_DURATION_IN_SEGS} from '../../config'
+import React, { useEffect, useState } from 'react'
 
 interface SubscriptionsProps {
-  purchaseDate: Date
+  purchaseDate: Date | undefined
   currentSubscription: UserSubscription | undefined
 }
 
 export function Subscriptions({ purchaseDate, currentSubscription }: SubscriptionsProps) {
 
-  let endOfSubscription: Date = new Date()
-  if (currentSubscription) {
-    endOfSubscription =new Date(purchaseDate)
-    endOfSubscription.setSeconds(endOfSubscription.getSeconds() + SUBSCRIPTION_DURATION_IN_SEGS)
+  const [endOfSubscription, seteEndOfSubscription] = useState<Date>()
+
+  const calculateEndSubscription = async () => {
+    if (currentSubscription && purchaseDate) {
+      const endSubscription =new Date(purchaseDate)
+      endSubscription.setSeconds(endSubscription.getSeconds() + SUBSCRIPTION_DURATION_IN_SEGS)
+      seteEndOfSubscription(endSubscription)
+    }
+
   }
+  
+  useEffect(() => {
+    calculateEndSubscription()
+  }, [])
 
 
   return (
@@ -27,11 +36,11 @@ export function Subscriptions({ purchaseDate, currentSubscription }: Subscriptio
               Your Subscription
             </UiText>
             { 
-              currentSubscription?
+              currentSubscription && purchaseDate?
               <UiLayout>
                 <UiText>{currentSubscription?.tier} </UiText>
-                <UiText> - Started: {purchaseDate.toLocaleDateString()}</UiText>
-                <UiText>-  Ends: {endOfSubscription.toLocaleDateString()}</UiText>
+                <UiText> - Started: {purchaseDate?.toLocaleDateString()}</UiText>
+                <UiText>-  Ends: {endOfSubscription?.toLocaleDateString()}</UiText>
               </UiLayout>
               :<UiText>No Subscription</UiText>
             }

--- a/client/src/components/+account/subscriptions.tsx
+++ b/client/src/components/+account/subscriptions.tsx
@@ -4,7 +4,7 @@ import {SUBSCRIPTION_DURATION_IN_SEGS} from '../../config'
 import React, { useEffect, useState } from 'react'
 
 interface SubscriptionsProps {
-  purchaseDate: Date | undefined
+  purchaseDate: Date | undefined
   currentSubscription: UserSubscription | undefined
 }
 
@@ -20,7 +20,7 @@ export function Subscriptions({ purchaseDate, currentSubscription }: Subscriptio
     }
 
   }
-  
+
   useEffect(() => {
     calculateEndSubscription()
   }, [])


### PR DESCRIPTION
## Description

Fix a bug reloading the subscription details when the user changes the account in metamask