### PR TITLE
Adjust the badge on summary

### DIFF
--- a/client/src/components/+account/account.module.scss
+++ b/client/src/components/+account/account.module.scss
@@ -159,4 +159,16 @@
     letter-spacing: -0.04em;
     color: #ffffff;
   }
+
+  &__subscription-badge {
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 32px;
+    padding: 4px 16px;
+
+    svg {
+      width: auto;
+      height: 18px;
+    }
+  }
 }

--- a/client/src/components/+account/summary.tsx
+++ b/client/src/components/+account/summary.tsx
@@ -12,6 +12,7 @@ interface SummaryProps {
 }
 
 const b = BEM('account-modules', styles)
+
 export function Summary({ published, bookmarks, downloaded, currentSubscription }: SummaryProps) {
   return (
     <>
@@ -26,9 +27,9 @@ export function Summary({ published, bookmarks, downloaded, currentSubscription 
             </UiText>
             <UiText className={b('summary-subscription')}>
               {currentSubscription ? (
-                <SubscriptionBadge tier={currentSubscription} />
+                <SubscriptionBadge className={b('subscription-badge')} tier={currentSubscription} />
               ) : (
-                'No Subscription'
+                <SubscriptionBadge className={b('subscription-badge')} tier="No Subscription" />
               )}
             </UiText>
           </UiLayout>


### PR DESCRIPTION
## Description

Adjust the summary badge on summary page according to [Figma](https://www.figma.com/file/qbvI8d1LQ353WlzUf0Y5Hp/Nevermined?node-id=5085%3A35689)

<img width="387" alt="Screenshot 2022-09-27 at 09 31 37" src="https://user-images.githubusercontent.com/1643399/192475590-5fe1566a-eb7d-4d5b-a604-dd80afd2c355.png">

<img width="387" alt="Screenshot 2022-09-27 at 09 31 44" src="https://user-images.githubusercontent.com/1643399/192475595-208683fe-83e3-496c-818d-4ad7476f6fda.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation